### PR TITLE
Adds more concrete installation instructions to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,18 @@
 # GLaDOS Voice Pack for Dreame Vacuum Robots
 
-using voice generation by [15.ai](https://15.ai/)
+Uses voice generation by [15.ai](https://15.ai/).
 
-md5 sum of the prepackaged `voice_pack.tar.gz`: `c34109f9012b855a42096d7987dd9bd5`
+MD5 sum of the prepackaged `voice_pack.tar.gz`:  
+`c34109f9012b855a42096d7987dd9bd5`
 
+Works at least with `L10 Pro` and `Z10 Pro`.
 
 ## Installation
 
 1. In Valetudo go to "Robot Settings" -> "Misc Settings"
 1. Enter the following information in the "Voice packs" section:
     - URL: `https://github.com/Findus23/voice_pack_dreame/raw/main/voice_pack.tar.gz`
-    - Language `Code: GLADOS`
+    - Language Code: `GLADOS`
     - Hash: `c34109f9012b855a42096d7987dd9bd5`
 1. Click "Set Voice Pack"
 

--- a/README.md
+++ b/README.md
@@ -1,16 +1,25 @@
-### GLaDOS Voice Pack for Dreame Vacuum Robots
+# GLaDOS Voice Pack for Dreame Vacuum Robots
 
 using voice generation by [15.ai](https://15.ai/)
 
-md5: `c34109f9012b855a42096d7987dd9bd5`
+md5 sum of the prepackaged `voice_pack.tar.gz`: `c34109f9012b855a42096d7987dd9bd5`
 
 
---------------
+## Installation
 
-Interestingly on my L10 Pro running `Valetudo 2022.03.0` the .tar.gz doesn't seem to work (`/data/personalized_voice/GLADOS` stays empty). But as the setting is set correctly, copying the files into the right directory seems to work:
+1. In Valetudo go to "Robot Settings" -> "Misc Settings"
+1. Enter the following information in the "Voice packs" section:
+    - URL: `https://github.com/Findus23/voice_pack_dreame/raw/main/voice_pack.tar.gz`
+    - Language `Code: GLADOS`
+    - Hash: `c34109f9012b855a42096d7987dd9bd5`
+1. Click "Set Voice Pack"
+
+Interestingly on my L10 Pro running `Valetudo 2022.03.0` the .tar.gz doesn't seem to work and the newly created folder `/data/personalized_voice/GLADOS` stays empty.
+However, the language code is set correctly in Valetudo and manually copying the files into the right directory works:
 
 ```
-scp output/* root@staubsauger.fritz.box:/data/personalized_voice/GLADOS
+git clone https://github.com/Findus23/voice_pack_dreame
+scp voice_pack_dreame/output/* root@<YOUR_ROBOT_ADDRESS>:/data/personalized_voice/GLADOS
 ```
 
 -----


### PR DESCRIPTION
Thanks for creating the language pack.

It was my first time installing one in Valetudo and I was a bit confused about the folder. These instructions should make it a bit more clear for newbies.

I can also confirm that using a `Z10 pro` with `2022.05.0` has the same issues when uploading the file and the workaround is still necessary.